### PR TITLE
Strip preceding slash words from FX name using formatting function

### DIFF
--- a/MFX-list.lua
+++ b/MFX-list.lua
@@ -489,6 +489,23 @@ local function setLastTouchedTrack(track)
   
 end -- setLastTouchedTrack
 --------------------------------------------------------
+function split(str, sep)
+    local sep, fields = sep, {}
+    local pattern = str.format("([^%s]+)", sep)
+    str:gsub(
+        pattern,
+        function(c)
+            fields[#fields + 1] = c
+        end
+    )
+    return fields
+end
+--------------------------------------------------------
+local function formatFXNameAndType(fxname, fxtype)
+    local segments = split(fxname, "/")
+    return fxtype .. " " .. segments[#segments]
+end
+--------------------------------------------------------
 local function collectFX(track)
   assert(track, "collectFX: invalid parameter - track")
   
@@ -498,8 +515,7 @@ local function collectFX(track)
   for i = 1, numfx do
     local _, fxname = rpr.TrackFX_GetFXName(track, i-1, "")
     local fxtype = fxname:match(MFXlist.MATCH_UPTOCOLON) or "VID:"  -- Video processor FX don't have prefixes
-    fxname = fxname:gsub(MFXlist.MATCH_UPTOCOLON.."%s", "") -- up to colon and then space, replace by nothing
-    fxname = fxname:gsub("%([^()]*%)","")
+    fxname = formatFXNameAndType(fxname, fxtype)
     local enabled =  rpr.TrackFX_GetEnabled(track, i-1)
     local offlined = rpr.TrackFX_GetOffline(track, i-1)
     table.insert(fxtab, {fxname = fxname, fxtype = fxtype, enabled = enabled, offlined = offlined}) -- confusing <key, value> pairs here, but it works

--- a/MFX-list.lua
+++ b/MFX-list.lua
@@ -501,9 +501,25 @@ function split(str, sep)
     return fields
 end
 --------------------------------------------------------
+-- TODO: Move this
+local DISPLAY_FX_TYPE_IN_LABEL = false
 local function formatFXNameAndType(fxname, fxtype)
     local segments = split(fxname, "/")
-    return fxtype .. " " .. segments[#segments]
+    local trimmed_fx_name = segments[#segments]
+
+    -- Strip parenthesized text
+    trimmed_fx_name = trimmed_fx_name:gsub("%([^()]*%)", "")
+
+    -- JSFX doesn't have "JS:" appended to it like "VST" does, so let's fake-append it for uniformity and easier if/else logic
+    if fxtype == "JS:" then
+        trimmed_fx_name = "JS: " .. trimmed_fx_name
+    end
+
+    if not DISPLAY_FX_TYPE_IN_LABEL then
+        trimmed_fx_name = trimmed_fx_name:gsub(MFXlist.MATCH_UPTOCOLON .. "%s", "") -- up to colon and then space, replace by nothing
+    end
+
+    return trimmed_fx_name
 end
 --------------------------------------------------------
 local function collectFX(track)


### PR DESCRIPTION
Strips the preceding words and slashes from long names like `JS: Witti/Waveshaper/waveshaper_nonlinear`.

Adds a boolean toggle to optionally display FX type `JS:`/`VSTi:`/`VST:` etc in front of FX in the list, defaulting to `false` (current behavior).

In the future this second feature may be redundant with addition of color coded FX items, or it may also still be useful to some folks. Not sure haha 🤷 

![AcrOZ1uBwv](https://user-images.githubusercontent.com/26604994/107137030-82b32280-68d6-11eb-9998-8d3458fdaf5f.gif)
